### PR TITLE
Feat: Parser.set 타입 가드 구현

### DIFF
--- a/src/Error.js
+++ b/src/Error.js
@@ -29,4 +29,8 @@ export const ErrorMessage = {
         base: "limit.base 는 number 타입이어야 합니다.",
         offset: "limit.offset 은 number 타입이어야 합니다.",
     },
+    set: {
+        object: "set은 객체 리터럴이어야 합니다.",
+        property: "set 객체는 하나 이상의 key-value 를 갖고 있어야 합니다.",
+    },
 };

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -16,16 +16,14 @@ class Parser {
     }
 
     static set(set) {
-        if (typeof set === "object") {
-            const setArray = Object.entries(set).map(([key, value]) => {
-                const escapeKey = wrapBacktick(key);
-                const excapeValue = typeof value === "string" ? `'${value}'` : value;
-                return `${escapeKey} = ${excapeValue}`;
-            });
-            return setArray.join(", ");
-        }
-        else if (typeof set == "string") return set;
-        else throw new Error("Check Input");
+        Validator.checkSet(set);
+
+        const setArray = Object.entries(set).map(([key, value]) => {
+            const escapeKey = wrapBacktick(key);
+            const excapeValue = typeof value === "string" ? `'${value}'` : value;
+            return `${escapeKey} = ${excapeValue}`;
+        });
+        return setArray.join(", ");
     }
 
     static values(values) {

--- a/src/Validator.js
+++ b/src/Validator.js
@@ -1,6 +1,6 @@
 import { ErrorMessage } from "./Error.js";
 
-class Validator {
+class TypeChecker {
     /**
      * 배열의 원소가 어떤 타입인지 반환하는 함수
      * @param {any[]} arr
@@ -25,6 +25,12 @@ class Validator {
         return types.every((t) => t === type);
     }
 
+    static isObjectLiteral(obj) {
+        return obj && Object.getPrototypeOf(obj) === Object.prototype;
+    }
+}
+
+class Validator extends TypeChecker {
     static checkCols(cols) {
         // cols가 배열이면서 원소가 string 타입인지 확인
         const isArray = Array.isArray(cols);
@@ -156,6 +162,15 @@ class Validator {
         // 3. limit.offset 이 number 타입인지 확인
         const isNumberOffset = typeof limit.offset === "number" && !Number.isNaN(limit.offset);
         if (!isNumberOffset) throw TypeError(ErrorMessage.limit.offset);
+    }
+
+    static checkSet(set) {
+        // 1. 객체 리터럴 타입인지 확인
+        const isObjectLiteral = Validator.isObjectLiteral(set);
+        if (!isObjectLiteral) throw TypeError(ErrorMessage.set.object);
+        // 2. 프로퍼티가 존재하는지 확인
+        const hasProperty = Object.keys(set).length > 0;
+        if (!hasProperty) throw TypeError(ErrorMessage.set.property);
     }
 }
 


### PR DESCRIPTION
## 주요 변경 사항

- Error.js : Parser.set 타입 에러 메시지 추가
- Validator.js : Parser.set 타입 가드 구현, TypeChecker클래스와 Validator클래스로 분리
    - TypeChecker 클래스는 순수하게 특정 값의 타입만 검사하는 모듈
    - Validator 클래스는 Parser 클래스의 메서드로 전달된 값이 유효한지 검사하는 모듈