### PR TITLE
Jae hyeok

### DIFF
--- a/src/CRUD.js
+++ b/src/CRUD.js
@@ -1,8 +1,7 @@
-import { ErrorMessage } from "./Error.js";
+import { ErrorMessage } from "./consts/Error.js";
 import Parser from "./Parser.js";
 
 export function select({ distinct, cols, from, where, groupBy, having, orderBy, limit, join }) {
-    if (!Array.isArray(cols) || !Array.isArray(from)) throw TypeError(ErrorMessage.select.required);
     distinct = distinct ? Parser.distinct(distinct) : "";
     cols = Parser.cols(cols);
     from = Parser.from(from);

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -61,7 +61,7 @@ class Parser {
         for (const { type, from, on } of joins) {
             const joinStatement = [];
             joinStatement.push(`${type} JOIN`);
-            joinStatement.push(Parser.from([from]));
+            joinStatement.push(wrapBacktick(from));
             joinStatement.push(`ON ${wrapBacktickExpression(on)}`);
             result.push(joinStatement.join(" "));
         }

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -76,7 +76,7 @@ class Parser {
 
         const columnsWithOrder = orderBy.cols.map((col, index) => {
             const order = orderBy.order[index];
-            return `\`${col}\` ${order}`;
+            return `${wrapBacktick(col)} ${order}`;
         });
 
         return `ORDER BY ${columnsWithOrder.join(", ")}`;
@@ -105,7 +105,7 @@ class Parser {
 
         // 3. offset이 숫자일 경우와 없을 경우 처리
         if (typeof offset === "number" && !Number.isNaN(offset)) {
-            return `LIMIT ${base}, ${offset}`;
+            return `LIMIT ${offset}, ${base}`;
         } else {
             return `LIMIT ${base}`;
         }

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -8,7 +8,7 @@ class Parser {
         else {
             cols = cols.map((e) => wrapBacktick(e));
             const colsStr = cols.join(", ");
-            return `(${colsStr})`;
+            return `${colsStr}`;
         }
     }
 

--- a/src/Validator.js
+++ b/src/Validator.js
@@ -1,4 +1,4 @@
-import { ErrorMessage } from "./Error.js";
+import { ErrorMessage } from "./consts/Error.js";
 
 class TypeChecker {
     /**
@@ -141,7 +141,6 @@ class Validator {
         // 3. groupBy.cols 배열의 원소가 전부 string 타입인지 확인
         const isStringCols = groupBy.cols.every((col) => typeof col === "string");
         if (!isStringCols) throw TypeError(ErrorMessage.groupBy.cols);
-
     }
 
     static checkWhere(where) {
@@ -152,8 +151,7 @@ class Validator {
 
     static checkLimit(limit) {
         // limit 객체가 base 속성을 갖는지 확인
-        const hasValidBaseProperty =
-            Object.prototype.hasOwnProperty.call(limit, "base");
+        const hasValidBaseProperty = Object.prototype.hasOwnProperty.call(limit, "base");
 
         if (!hasValidBaseProperty) {
             throw TypeError(ErrorMessage.limit.property);

--- a/src/consts/Error.js
+++ b/src/consts/Error.js
@@ -5,7 +5,7 @@ export const ErrorMessage = {
     join: {
         array: "join 은 배열이어야 합니다.",
         property: "join배열의 각 원소는 type, from, on 속성을 갖는 객체이어야 합니다.",
-        type: "join의 type은 LEFT, RIGHT, SELF, INNER, OUTER, FULL 중 하나여야 합니다.",
+        type: "join의 type은 LEFT, RIGHT 중 하나여야 합니다.",
     },
     values: {
         twoDimensionArray: "values는 2차원 배열이어야 합니다.",

--- a/src/consts/Join.js
+++ b/src/consts/Join.js
@@ -1,0 +1,4 @@
+export const JOIN = {
+    LEFT: "LEFT",
+    RIGHT: "RIGHT",
+};

--- a/src/test/Parser.test.js
+++ b/src/test/Parser.test.js
@@ -1,5 +1,6 @@
 import Parser from "../Parser.js";
-import { ErrorMessage } from "../Error.js";
+import { ErrorMessage } from "../consts/Error.js";
+import { JOIN } from "../consts/Join.js";
 
 function colsTest() {
     // given
@@ -16,7 +17,7 @@ function colsTest() {
     });
     // then
     const expected = [
-        "(`name`, `age`)",
+        "`name`, `age`",
         new TypeError(ErrorMessage.cols),
         new TypeError(ErrorMessage.cols),
         "*",
@@ -37,24 +38,24 @@ function joinTest() {
     const inputs = [
         [
             {
-                type: "INNER",
+                type: JOIN.LEFT,
                 from: "orders",
                 on: "customers.customer_id = orders.customer_id",
             },
             {
-                type: "OUTER",
+                type: JOIN.RIGHT,
                 from: "order_items",
                 on: "orders.order_id = order_items.order_id",
             },
             {
-                type: "FULL",
+                type: JOIN.LEFT,
                 from: "products",
                 on: "order_items.product_id = products.product_id",
             },
         ],
         [
             {
-                type: "INNER",
+                type: JOIN.LEFT,
                 from: "orders",
             },
         ],
@@ -79,13 +80,15 @@ function joinTest() {
     });
     // then
     const expected = [
-        `INNER JOIN \`orders\` ON \`customers\`.\`customer_id\` = \`orders\`.\`customer_id\`
-OUTER JOIN \`order_items\` ON \`orders\`.\`order_id\` = \`order_items\`.\`order_id\`
-FULL JOIN \`products\` ON \`order_items\`.\`product_id\` = \`products\`.\`product_id\``,
+        `LEFT JOIN \`orders\` ON \`customers\`.\`customer_id\` = \`orders\`.\`customer_id\`
+RIGHT JOIN \`order_items\` ON \`orders\`.\`order_id\` = \`order_items\`.\`order_id\`
+LEFT JOIN \`products\` ON \`order_items\`.\`product_id\` = \`products\`.\`product_id\``,
         new TypeError(ErrorMessage.join.property),
         new TypeError(ErrorMessage.join.type),
         new TypeError(ErrorMessage.join.array),
     ];
+    // console.log("Results: ", results);
+    // console.log("Expected: ", expected);
 
     const isPass = results.every((result, i) => {
         if (result instanceof TypeError) {
@@ -271,7 +274,6 @@ function groupByTest() {
         new TypeError(ErrorMessage.groupBy.property),
     ];
 
-  
     const isPass = results.every((result, i) => {
         if (result instanceof TypeError) {
             return result.message === expected[i].message;
@@ -368,12 +370,12 @@ function limitTest() {
     });
     // then
     const expected = [
-      "LIMIT 10, 20",  // 정상적인 출력
-        "LIMIT 5",  // 정상적인 출력
-        new TypeError(ErrorMessage.limit.base),  // base 값이 잘못된 경우
-        new TypeError(ErrorMessage.limit.property)  // 잘못된 limit 형식
+        "LIMIT 10, 20", // 정상적인 출력
+        "LIMIT 5", // 정상적인 출력
+        new TypeError(ErrorMessage.limit.base), // base 값이 잘못된 경우
+        new TypeError(ErrorMessage.limit.property), // 잘못된 limit 형식
     ];
-    
+
     const isPass = results.every((result, i) => {
         if (result instanceof TypeError) {
             return result.message === expected[i].message;
@@ -387,12 +389,12 @@ function limitTest() {
 function setTest() {
     // given
     const inputs = [
-        { name: "John", age: 25, active: true },  // 정상적인 객체 리터럴
-        {},                                        // 프로퍼티가 없는 객체 (에러 발생 예상)
-        "invalid",                                 // 객체 리터럴이 아닌 값 (에러 발생 예상)
-        { salary: 5000, position: "Manager" },    // 숫자와 문자열이 혼합된 객체
-        { invalidKey: null },                     // null 값이 포함된 객체 (정상 처리 예상)
-        new Map()                                 // 객체 리터럴이 아닌 값 (에러 발생 예상)
+        { name: "John", age: 25, active: true }, // 정상적인 객체 리터럴
+        {}, // 프로퍼티가 없는 객체 (에러 발생 예상)
+        "invalid", // 객체 리터럴이 아닌 값 (에러 발생 예상)
+        { salary: 5000, position: "Manager" }, // 숫자와 문자열이 혼합된 객체
+        { invalidKey: null }, // null 값이 포함된 객체 (정상 처리 예상)
+        new Map(), // 객체 리터럴이 아닌 값 (에러 발생 예상)
     ];
 
     // when
@@ -408,12 +410,12 @@ function setTest() {
 
     // then
     const expected = [
-        "`name` = 'John', `age` = 25, `active` = true",  // 정상 처리 예상
-        new TypeError(ErrorMessage.set.property),        // 프로퍼티가 없는 객체, 에러 발생
-        new TypeError(ErrorMessage.set.object),          // 객체 리터럴이 아닌 값, 에러 발생
-        "`salary` = 5000, `position` = 'Manager'",       // 정상 처리 예상
-        "`invalidKey` = null",                           // null 값 정상 처리 예상
-        new TypeError(ErrorMessage.set.object)           // Map 객체, 에러 발생
+        "`name` = 'John', `age` = 25, `active` = true", // 정상 처리 예상
+        new TypeError(ErrorMessage.set.property), // 프로퍼티가 없는 객체, 에러 발생
+        new TypeError(ErrorMessage.set.object), // 객체 리터럴이 아닌 값, 에러 발생
+        "`salary` = 5000, `position` = 'Manager'", // 정상 처리 예상
+        "`invalidKey` = null", // null 값 정상 처리 예상
+        new TypeError(ErrorMessage.set.object), // Map 객체, 에러 발생
     ];
 
     const isPass = results.every((result, i) => {
@@ -436,4 +438,6 @@ distinctTest();
 intoTest();
 havingTest();
 setTest();
-valueTest();
+valuesTest();
+fromTest();
+orderByTest();


### PR DESCRIPTION
## 주요 변경 사항
- SELECT 구문에서 컬럼명 괄호로 감싸지 않도록 수정
- JOIN 절 타입 LEFT, RIGHT 로 제한
- `Parser.limit()`: offset, base 순서 올바르게 수정
- `Parser.orderBy()`: 반환하는 컬럼명 직접 백틱으로 감싸는 대신 wrapBacktick 메서드 사용 ( 컬럼명이 `table.column` 인 경우 고려 )